### PR TITLE
Ability to specify PropertyBag namespace from config

### DIFF
--- a/src/Helpers/NameResolver.php
+++ b/src/Helpers/NameResolver.php
@@ -17,6 +17,14 @@ class NameResolver
     }
 
     /**
+     * @return string|null
+     */
+    private static function getConfigNamespace()
+    {
+        return config('property_bag.namespace');
+    }
+
+    /**
      * Make config file name for resource.
      *
      * @param string $resourceName
@@ -25,6 +33,10 @@ class NameResolver
      */
     public static function makeConfigFileName($resourceName)
     {
+        if ($namespace = static::getConfigNamespace()) {
+            return $namespace.'\\'.$resourceName.'Settings';
+        }
+
         $appNamespace = static::getAppNamespace();
 
         return $appNamespace.'Settings\\'.$resourceName.'Settings';
@@ -37,6 +49,10 @@ class NameResolver
      */
     public static function makeRulesFileName()
     {
+        if ($namespace = static::getConfigNamespace()) {
+            return $namespace.'\\Resources\\Rules';
+        }
+
         $appNamespace = static::getAppNamespace();
 
         return $appNamespace.'Settings\\Resources\\Rules';

--- a/tests/Unit/Helpers/NameResolverTest.php
+++ b/tests/Unit/Helpers/NameResolverTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace LaravelPropertyBag\tests\Unit\Helpers;
+
+use LaravelPropertyBag\Helpers\NameResolver;
+use LaravelPropertyBag\tests\Classes\User;
+use LaravelPropertyBag\tests\TestCase;
+
+class NameResolverTest extends TestCase
+{
+    public function test_can_make_config_filename_if_no_user_namespace_config_set(): void
+    {
+        $namespace = NameResolver::makeConfigFileName(User::class);
+        $this->assertEquals('App\Settings\LaravelPropertyBag\tests\Classes\UserSettings', $namespace);
+    }
+
+    public function test_can_make_config_filename_if_user_namespace_config_set(): void
+    {
+        config([
+            'property_bag.namespace' => 'MyApp\\Settings'
+        ]);
+
+        $namespace = NameResolver::makeConfigFileName(User::class);
+        $this->assertEquals('MyApp\Settings\LaravelPropertyBag\tests\Classes\UserSettings', $namespace);
+    }
+
+    public function test_can_make_rules_filename_if_no_user_namespace_config_set(): void
+    {
+        $namespace = NameResolver::makeRulesFileName();
+        $this->assertEquals('App\Settings\Resources\Rules', $namespace);
+    }
+
+    public function test_can_make_rules_filename_if_user_namespace_config_set(): void
+    {
+        config([
+            'property_bag.namespace' => 'MyApp\\Settings'
+        ]);
+
+        $namespace = NameResolver::makeRulesFileName();
+        $this->assertEquals('MyApp\Settings\Resources\Rules', $namespace);
+    }
+}

--- a/tests/Unit/Helpers/NameResolverTest.php
+++ b/tests/Unit/Helpers/NameResolverTest.php
@@ -5,13 +5,25 @@ namespace LaravelPropertyBag\tests\Unit\Helpers;
 use LaravelPropertyBag\Helpers\NameResolver;
 use LaravelPropertyBag\tests\Classes\User;
 use LaravelPropertyBag\tests\TestCase;
+use ReflectionClass;
 
 class NameResolverTest extends TestCase
 {
+    /** @var string $shortClassName */
+    private $shortClassName;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $reflection = new ReflectionClass(new User());
+        $this->shortClassName = $reflection->getShortName();
+    }
+
     public function test_can_make_config_filename_if_no_user_namespace_config_set(): void
     {
-        $namespace = NameResolver::makeConfigFileName(User::class);
-        $this->assertEquals('App\Settings\LaravelPropertyBag\tests\Classes\UserSettings', $namespace);
+        $namespace = NameResolver::makeConfigFileName($this->shortClassName);
+        $this->assertEquals('App\Settings\UserSettings', $namespace);
     }
 
     public function test_can_make_config_filename_if_user_namespace_config_set(): void
@@ -20,8 +32,8 @@ class NameResolverTest extends TestCase
             'property_bag.namespace' => 'MyApp\\Settings'
         ]);
 
-        $namespace = NameResolver::makeConfigFileName(User::class);
-        $this->assertEquals('MyApp\Settings\LaravelPropertyBag\tests\Classes\UserSettings', $namespace);
+        $namespace = NameResolver::makeConfigFileName($this->shortClassName);
+        $this->assertEquals('MyApp\Settings\UserSettings', $namespace);
     }
 
     public function test_can_make_rules_filename_if_no_user_namespace_config_set(): void


### PR DESCRIPTION
We need the ability to specify a specific namespace that the config files will live in. This PR enables us to create a `config/property_bag.php` file which looks like this:

```
<?php

return [
  'namespace' => 'Some\\Custom\\Namespace',
];
```

This gives us finer control over where we want our settings to live when the application does not use the standard out of the box Laravel architecture.