### PR TITLE
ST-232 - upgrade php, laravel and fixes in test to remove old style

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,10 +11,10 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          php-versions: [ '7.2', '7.3', '7.4' ]
+          php-versions: [ '8.2', '8.3', '8.4' ]
 
       steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -29,12 +29,12 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-
+            ${{ runner.os }}-php-${{ matrix.php-versions }}-
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 composer.lock
 .idea
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "agensoftware/laravel-property-bag",
+    "name": "agentsoftware/laravel-property-bag",
     "description": "Easy Laravel user settings using a property bag",
     "type": "project",
     "keywords": ["laravel", "user", "settings", "property", "user settings", "propety bag"],

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,15 @@
     ],
 
     "require": {
-        "php": ">=7.1"
+        "php": "^8.2",
+        "illuminate/console": "^12.0",
+        "illuminate/database": "^12.0",
+        "illuminate/support": "^12.0"
     },
 
     "require-dev": {
-        "laravel/laravel": "^6.0",
-        "laravel/browser-kit-testing": "~1.0",
-        "phpunit/phpunit": "~4.0"
+        "orchestra/testbench": "^10.0",
+        "phpunit/phpunit": "^11.0"
     },
 
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
+         cacheDirectory=".phpunit.cache"
+         backupGlobals="false"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./tests/</directory>

--- a/tests/Classes/Admin.php
+++ b/tests/Classes/Admin.php
@@ -2,7 +2,7 @@
 
 namespace LaravelPropertyBag\tests\Classes;
 
-use App\User as BaseUser;
+use Illuminate\Foundation\Auth\User as BaseUser;
 use LaravelPropertyBag\Settings\HasSettings;
 
 class Admin extends BaseUser
@@ -15,4 +15,15 @@ class Admin extends BaseUser
      * @var string
      */
     protected $table = 'users';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
 }

--- a/tests/Classes/User.php
+++ b/tests/Classes/User.php
@@ -2,7 +2,7 @@
 
 namespace LaravelPropertyBag\tests\Classes;
 
-use App\User as BaseUser;
+use Illuminate\Foundation\Auth\User as BaseUser;
 use LaravelPropertyBag\Settings\HasSettings;
 
 class User extends BaseUser
@@ -15,6 +15,17 @@ class User extends BaseUser
      * @var string
      */
     protected $table = 'users';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
 
     /**
      * Settings config class.

--- a/tests/Functional/PropertyBagTest.php
+++ b/tests/Functional/PropertyBagTest.php
@@ -3,12 +3,11 @@
 namespace LaravelPropertyBag\tests\Functional;
 
 use LaravelPropertyBag\tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class PropertyBagTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function a_resource_can_access_and_use_the_property_bag()
     {
         $group = $this->makeGroup();
@@ -26,7 +25,7 @@ class PropertyBagTest extends TestCase
 
         $this->assertEquals('grapes', $settings->get('test_settings1'));
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $group->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\Group',
             'key'           => 'test_settings1',
@@ -37,7 +36,7 @@ class PropertyBagTest extends TestCase
 
         $this->assertEquals(false, $settings->get('test_settings2'));
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $group->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\Group',
             'key'           => 'test_settings2',
@@ -54,7 +53,7 @@ class PropertyBagTest extends TestCase
 
         $this->assertEquals('bananas', $settings->get('test_settings1'));
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $group->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\Group',
             'key'           => 'test_settings1',
@@ -65,7 +64,7 @@ class PropertyBagTest extends TestCase
 
         $this->assertEquals(true, $settings->get('test_settings2'));
 
-        $this->dontSeeInDatabase('property_bag', [
+        $this->assertDatabaseMissing('property_bag', [
             'resource_id'   => $group->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\Group',
             'key'           => 'test_settings2',
@@ -75,7 +74,7 @@ class PropertyBagTest extends TestCase
 
         $this->assertEquals('false', $settings->get('test_settings3'));
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $group->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\Group',
             'key'           => 'test_settings3',
@@ -83,9 +82,7 @@ class PropertyBagTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multiple_instances_of_same_resource_can_use_settings()
     {
         $user1 = $this->user;
@@ -103,7 +100,7 @@ class PropertyBagTest extends TestCase
             $user1->settings()->allSaved()->all()
         );
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $user1->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'key'           => 'test_settings1',
@@ -119,7 +116,7 @@ class PropertyBagTest extends TestCase
             $user2->settings()->allSaved()->all()
         );
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $user2->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'key'           => 'test_settings1',
@@ -136,7 +133,7 @@ class PropertyBagTest extends TestCase
 
         );
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $user3->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'key'           => 'test_settings1',
@@ -149,7 +146,7 @@ class PropertyBagTest extends TestCase
             $user1->settings()->allSaved()->all()
         );
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $user1->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'key'           => 'test_settings1',
@@ -157,9 +154,7 @@ class PropertyBagTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multiple_resources_can_use_settings()
     {
         $group = $this->makeGroup();
@@ -185,20 +180,20 @@ class PropertyBagTest extends TestCase
             $group->settings()->all()->all()
         );
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $group->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\Group',
             'key'           => 'test_settings1',
             'value'         => json_encode('[8]'),
         ]);
 
-        $this->dontSeeInDatabase('property_bag', [
+        $this->assertDatabaseMissing('property_bag', [
             'resource_id'   => $group->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\Group',
             'key'           => 'test_settings2',
         ]);
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $group->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\Group',
             'key'           => 'test_settings3',
@@ -210,20 +205,20 @@ class PropertyBagTest extends TestCase
             $this->user->settings()->all()->all()
         );
 
-        $this->dontSeeInDatabase('property_bag', [
+        $this->assertDatabaseMissing('property_bag', [
             'resource_id'   => $this->user->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'key'           => 'test_settings1',
         ]);
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $this->user->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'key'           => 'test_settings2',
             'value'         => json_encode('[false]'),
         ]);
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $this->user->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'key'           => 'test_settings3',
@@ -237,14 +232,14 @@ class PropertyBagTest extends TestCase
             'bool'    => true,
         ]);
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $comment->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\Comment',
             'key'           => 'numeric',
             'value'         => json_encode('[10]'),
         ]);
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $comment->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\Comment',
             'key'           => 'bool',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,58 +2,69 @@
 
 namespace LaravelPropertyBag\tests;
 
-use Hash;
+use Illuminate\Support\Facades\Hash;
 use LaravelPropertyBag\ServiceProvider;
-use Illuminate\Contracts\Console\Kernel;
+use LaravelPropertyBag\tests\Classes\Admin;
+use LaravelPropertyBag\tests\Classes\Comment;
+use LaravelPropertyBag\tests\Classes\Group;
 use LaravelPropertyBag\tests\Classes\Post;
 use LaravelPropertyBag\tests\Classes\User;
-use LaravelPropertyBag\tests\Classes\Admin;
-use LaravelPropertyBag\tests\Classes\Group;
-use LaravelPropertyBag\tests\Classes\Comment;
-use Laravel\BrowserKitTesting\TestCase as BaseTestCase;
+use LaravelPropertyBag\tests\Migrations\CreateCommentsTable;
+use LaravelPropertyBag\tests\Migrations\CreateGroupsTable;
 use LaravelPropertyBag\tests\Migrations\CreatePostsTable;
 use LaravelPropertyBag\tests\Migrations\CreateUsersTable;
-use LaravelPropertyBag\tests\Migrations\CreateGroupsTable;
-use LaravelPropertyBag\tests\Migrations\CreateCommentsTable;
+use Orchestra\Testbench\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
     /**
      * Testing property bag register.
      *
-     * @var Collection
+     * @var \Illuminate\Support\Collection
      */
     protected $registered;
 
     /**
-     * Creates the application.
+     * Test user.
      *
-     * @return \Illuminate\Foundation\Application
+     * @var User
      */
-    public function createApplication()
+    protected $user;
+
+    /**
+     * Register the package service provider.
+     *
+     * @param \Illuminate\Foundation\Application $app
+     *
+     * @return array
+     */
+    protected function getPackageProviders($app)
     {
-        $app = require __DIR__.'/../vendor/laravel/laravel/bootstrap/app.php';
+        return [ServiceProvider::class];
+    }
 
-        $app->register(ServiceProvider::class);
+    /**
+     * Use an in-memory sqlite database for the test app.
+     *
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'sqlite');
 
-        $app->make(Kernel::class)->bootstrap();
-
-        return $app;
+        $app['config']->set('database.connections.sqlite', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
     }
 
     /**
      * Setup DB and test variables before each test.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
-
-        $this->app['config']->set('database.default', 'sqlite');
-
-        $this->app['config']->set(
-            'database.connections.sqlite.database',
-            ':memory:'
-        );
 
         $this->migrate();
 
@@ -85,7 +96,7 @@ abstract class TestCase extends BaseTestCase
      * Make a user.
      *
      * @param string $name
-     * @param string $password
+     * @param string $email
      *
      * @return User
      */
@@ -104,7 +115,7 @@ abstract class TestCase extends BaseTestCase
      * Make an admin user (should fail to get settings).
      *
      * @param string $name
-     * @param string $password
+     * @param string $email
      *
      * @return Admin
      */
@@ -134,9 +145,9 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
-     * Make a group.
+     * Make a post.
      *
-     * @return Group
+     * @return Post
      */
     protected function makePost()
     {
@@ -148,9 +159,9 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
-     * Make a group.
+     * Make a comment.
      *
-     * @return Group
+     * @return Comment
      */
     protected function makeComment()
     {

--- a/tests/Unit/CommandTest.php
+++ b/tests/Unit/CommandTest.php
@@ -2,18 +2,17 @@
 
 namespace LaravelPropertyBag\tests\Unit;
 
-use File;
 use Artisan;
+use File;
 use LaravelPropertyBag\tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class CommandTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function publish_user_command_creates_settings_file()
     {
-        $this->assertFileNotExists(app_path('Settings/UserSettings.php'));
+        $this->assertFileDoesNotExist(app_path('Settings/UserSettings.php'));
 
         Artisan::call('pbag:make', ['resource' => 'User']);
 
@@ -22,9 +21,7 @@ class CommandTest extends TestCase
         File::deleteDirectory(app_path('Settings'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function published_settings_file_has_correct_namespace()
     {
         Artisan::call('pbag:make', ['resource' => 'User']);
@@ -36,9 +33,7 @@ class CommandTest extends TestCase
         File::deleteDirectory(app_path('Settings'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function published_settings_file_has_correct_name()
     {
         Artisan::call('pbag:make', ['resource' => 'User']);
@@ -50,12 +45,10 @@ class CommandTest extends TestCase
         File::deleteDirectory(app_path('Settings'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function publish_rules_file_creates_rules_file()
     {
-        $this->assertFileNotExists(app_path('Settings/Resources/Rules.php'));
+        $this->assertFileDoesNotExist(app_path('Settings/Resources/Rules.php'));
 
         Artisan::call('pbag:rules');
 

--- a/tests/Unit/HasSettingsTest.php
+++ b/tests/Unit/HasSettingsTest.php
@@ -3,12 +3,11 @@
 namespace LaravelPropertyBag\tests\Unit;
 
 use LaravelPropertyBag\tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class HasSettingsTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function if_key_is_given_to_settings_method_value_is_returned()
     {
         $value = $this->user->settings('test_settings1');
@@ -16,9 +15,7 @@ class HasSettingsTest extends TestCase
         $this->assertEquals('monkey', $value);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function if_array_is_given_to_settings_method_value_is_set()
     {
         $settings = [
@@ -32,7 +29,7 @@ class HasSettingsTest extends TestCase
             $this->user->settings()->allSaved()->all()
         );
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $this->user->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'key'           => 'test_settings1',
@@ -40,9 +37,7 @@ class HasSettingsTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function settings_can_be_set_with_from_hassettings()
     {
         $settings = [
@@ -57,14 +52,14 @@ class HasSettingsTest extends TestCase
             $this->user->settings()->allSaved()->all()
         );
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $this->user->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'key'           => 'test_settings1',
             'value'         => json_encode('["bananas"]'),
         ]);
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $this->user->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'key'           => 'test_settings3',
@@ -72,9 +67,7 @@ class HasSettingsTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function all_settings_can_be_retrieved_from_hassettings()
     {
         $settings = [
@@ -92,9 +85,7 @@ class HasSettingsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function default_setting_can_be_retrieved_from_hassettings()
     {
         $default = $this->user->defaultSetting('test_settings1');
@@ -102,9 +93,7 @@ class HasSettingsTest extends TestCase
         $this->assertEquals('monkey', $default);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function all_defaults_can_be_retrieved_from_hassettings()
     {
         $defaults = $this->user->defaultSetting();
@@ -116,9 +105,7 @@ class HasSettingsTest extends TestCase
         ], $defaults->all());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function allowed_settings_for_single_key_can_be_retrieved_from_hassettings()
     {
         $allowed = $this->user->allowedSetting('test_settings1');
@@ -126,9 +113,7 @@ class HasSettingsTest extends TestCase
         $this->assertEquals(['bananas', 'grapes', 8, 'monkey'], $allowed->all());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function all_allowed_values_can_be_retrieved_from_hassettings()
     {
         $allowed = $this->user->allowedSetting();
@@ -142,9 +127,7 @@ class HasSettingsTest extends TestCase
         $this->assertEquals($actual, $allowed->all());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function all_resources_with_setting_can_be_retrieved_from_hassettings()
     {
         $this->assertCount(1, $this->user::withSetting('test_settings1'));
@@ -152,9 +135,7 @@ class HasSettingsTest extends TestCase
         $this->assertCount(0, $this->user::withSetting('test_settings_invalid'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function all_resources_with_setting_and_value_can_be_retrieved_from_hassettings()
     {
         $this->assertCount(1, $this->user::withSetting('test_settings1', 'monkey'));

--- a/tests/Unit/Helpers/NameResolverTest.php
+++ b/tests/Unit/Helpers/NameResolverTest.php
@@ -12,7 +12,7 @@ class NameResolverTest extends TestCase
     /** @var string $shortClassName */
     private $shortClassName;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/RuleTest.php
+++ b/tests/Unit/RuleTest.php
@@ -3,14 +3,14 @@
 namespace LaravelPropertyBag\tests\Unit;
 
 use File;
-use LaravelPropertyBag\tests\TestCase;
+use LaravelPropertyBag\Exceptions\InvalidSettingsRule;
 use LaravelPropertyBag\Settings\Rules\RuleValidator;
+use LaravelPropertyBag\tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class RuleTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function rule_validator_can_correctly_identify_rules()
     {
         $validator = new RuleValidator();
@@ -29,20 +29,16 @@ class RuleTest extends TestCase
         $this->assertFalse($validator->isRule('test:'));
     }
 
-    /**
-     * @test
-     *
-     * @expectedException LaravelPropertyBag\Exceptions\InvalidSettingsRule
-     * @expectedExceptionMessage Method ruleNope for rule nope not found. Check rule spelling or create method ruleNope in Rules.php.
-     */
+    #[Test]
     public function throws_exception_for_rule_not_declared()
     {
+        $this->expectException(InvalidSettingsRule::class);
+        $this->expectExceptionMessage('Method ruleNope for rule nope not found. Check rule spelling or create method ruleNope in Rules.php.');
+
         $this->makeComment()->settings()->isValid('invalid', 'test');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function any_rule_returns_true_for_any()
     {
         $this->assertTrue(
@@ -50,9 +46,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function alpha_rule_returns_true_for_alpha()
     {
         $this->assertTrue(
@@ -60,9 +54,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function alpha_rule_returns_false_for_non_alpha()
     {
         $this->assertFalse(
@@ -70,9 +62,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function alphanum_rule_returns_true_for_alphanum()
     {
         $this->assertTrue(
@@ -80,9 +70,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function alphanum_rule_returns_false_for_non_alphanum()
     {
         $this->assertFalse(
@@ -90,9 +78,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function bool_rule_returns_true_for_bool()
     {
         $this->assertTrue(
@@ -100,9 +86,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function bool_rule_returns_false_for_non_bool()
     {
         $this->assertFalse(
@@ -110,9 +94,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function integer_rule_returns_true_for_integer()
     {
         $this->assertTrue(
@@ -120,9 +102,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function integer_rule_returns_false_for_non_integer()
     {
         $this->assertFalse(
@@ -130,9 +110,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function numeric_rule_returns_true_for_numeric()
     {
         $this->assertTrue(
@@ -140,9 +118,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function numeric_rule_returns_false_for_non_numeric()
     {
         $this->assertFalse(
@@ -150,9 +126,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function range_rule_returns_true_for_value_in_range()
     {
         $this->assertTrue(
@@ -160,9 +134,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function range_rule_returns_true_for_value_at_low_end()
     {
         $this->assertTrue(
@@ -170,9 +142,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function range_rule_returns_true_for_value_at_high_end()
     {
         $this->assertTrue(
@@ -180,9 +150,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function range_rule_returns_false_for_value_out_of_range()
     {
         $this->assertFalse(
@@ -190,9 +158,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function range_rule_handles_negative_numbers()
     {
         $comment = $this->makeComment();
@@ -206,9 +172,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function string_rule_returns_true_for_string()
     {
         $this->assertTrue(
@@ -216,9 +180,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function string_rule_returns_false_for_non_string()
     {
         $this->assertFalse(
@@ -226,9 +188,7 @@ class RuleTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function rules_can_be_user_defined()
     {
         File::makeDirectory(app_path('Settings'));

--- a/tests/Unit/SettingsTest.php
+++ b/tests/Unit/SettingsTest.php
@@ -3,36 +3,32 @@
 namespace LaravelPropertyBag\tests\Unit;
 
 use Illuminate\Support\Collection;
-use LaravelPropertyBag\tests\TestCase;
+use LaravelPropertyBag\Exceptions\InvalidSettingsValue;
+use LaravelPropertyBag\Exceptions\ResourceNotFound;
+use LaravelPropertyBag\Settings\ResourceConfig;
 use LaravelPropertyBag\Settings\Settings;
 use LaravelPropertyBag\tests\Classes\User;
-use LaravelPropertyBag\Settings\ResourceConfig;
-use LaravelPropertyBag\Exceptions\InvalidSettingsValue;
+use LaravelPropertyBag\tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class SettingsTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function a_resource_can_access_the_settings_object()
     {
         $this->assertInstanceOf(Settings::class, $this->user->settings());
     }
 
-    /**
-     * @test
-     *
-     * @expectedException LaravelPropertyBag\Exceptions\ResourceNotFound
-     * @expectedExceptionMessage Class App\Settings\AdminSettings not found.
-     */
+    #[Test]
     public function exception_is_thrown_when_config_file_not_found()
     {
+        $this->expectException(ResourceNotFound::class);
+        $this->expectExceptionMessage('Class App\Settings\AdminSettings not found.');
+
         $this->makeAdmin()->settings();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function settings_class_has_registered_settings()
     {
         $registered = $this->user->settings()->getRegistered();
@@ -42,9 +38,7 @@ class SettingsTest extends TestCase
         $this->assertCount(17, $registered->flatten());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resource_config_can_access_orignal_model()
     {
         $resourceConfig = $this->user->settings()->getResourceConfig();
@@ -58,9 +52,7 @@ class SettingsTest extends TestCase
         $this->assertEquals($this->user->id, $resource->id);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function settings_class_can_check_for_registered_settings()
     {
         $group = $this->makeGroup();
@@ -70,9 +62,7 @@ class SettingsTest extends TestCase
         $this->assertTrue($settings->isRegistered('test_settings1'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function a_valid_setting_key_value_pair_passes_validation()
     {
         $result = $this->user->settings()->isValid('test_settings1', 'bananas');
@@ -80,9 +70,7 @@ class SettingsTest extends TestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function an_invalid_setting_key_fails_validation()
     {
         $result = $this->user->settings()->isValid('fake', true);
@@ -90,9 +78,7 @@ class SettingsTest extends TestCase
         $this->assertFalse($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function an_invalid_setting_value_fails_validation()
     {
         $result = $this->user->settings()->isValid('test_settings2', 'ok');
@@ -100,9 +86,7 @@ class SettingsTest extends TestCase
         $this->assertFalse($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function a_default_value_can_de_detected()
     {
         $result = $this->user->settings()->isDefault('test_settings3', false);
@@ -110,9 +94,7 @@ class SettingsTest extends TestCase
         $this->assertTrue($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function a_non_default_value_can_de_detected()
     {
         $result = $this->user->settings()->isDefault('test_settings3', true);
@@ -120,9 +102,7 @@ class SettingsTest extends TestCase
         $this->assertFalse($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function a_resource_can_get_the_default_value()
     {
         $default = $this->user->settings()->getDefault('test_settings1');
@@ -130,9 +110,7 @@ class SettingsTest extends TestCase
         $this->assertEquals('monkey', $default);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function a_resource_can_get_all_the_default_values()
     {
         $defaults = $this->user->settings()->allDefaults();
@@ -144,9 +122,7 @@ class SettingsTest extends TestCase
         ], $defaults->all());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function a_resource_can_get_the_allowed_values()
     {
         $allowed = $this->user->settings()->getAllowed('test_settings1');
@@ -154,9 +130,7 @@ class SettingsTest extends TestCase
         $this->assertEquals(['bananas', 'grapes', 8, 'monkey'], $allowed->all());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function a_resource_can_get_all_allowed_values()
     {
         $allowed = $this->user->settings()->allAllowed()->flatten();
@@ -164,23 +138,19 @@ class SettingsTest extends TestCase
         $this->assertCount(14, $allowed);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function adding_a_new_setting_creates_a_new_user_setting_record()
     {
         $this->user->settings()->set(['test_settings3' => true]);
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $this->user->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'value'         => json_encode('[true]'),
         ]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function adding_a_new_setting_refreshes_settings_on_object()
     {
         $this->assertEmpty($this->user->settings()->allSaved());
@@ -195,9 +165,7 @@ class SettingsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updating_a_setting_updates_the_setting_record()
     {
         $this->actingAs($this->user);
@@ -211,7 +179,7 @@ class SettingsTest extends TestCase
             $settings->allSaved()->all()
         );
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $this->user->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'key'           => 'test_settings1',
@@ -225,7 +193,7 @@ class SettingsTest extends TestCase
             $settings->allSaved()->all()
         );
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $this->user->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'key'           => 'test_settings1',
@@ -233,9 +201,7 @@ class SettingsTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function a_user_can_set_many_settings_at_once()
     {
         $this->actingAs($this->user);
@@ -253,14 +219,14 @@ class SettingsTest extends TestCase
 
         $this->assertEquals($test, $settings->allSaved()->all());
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $this->user->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'key'           => 'test_settings1',
             'value'         => json_encode('["grapes"]'),
         ]);
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id'   => $this->user->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'key'           => 'test_settings2',
@@ -268,9 +234,7 @@ class SettingsTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function a_user_can_get_a_setting()
     {
         $this->actingAs($this->user);
@@ -284,9 +248,7 @@ class SettingsTest extends TestCase
         $this->assertFalse($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function if_the_setting_is_not_set_the_default_value_is_returned()
     {
         $this->actingAs($this->user);
@@ -296,9 +258,7 @@ class SettingsTest extends TestCase
         $this->assertEquals('monkey', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function a_user_can_get_all_the_settings_being_used()
     {
         $this->actingAs($this->user);
@@ -316,9 +276,7 @@ class SettingsTest extends TestCase
         ], $this->user->settings()->all()->all());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function a_user_can_get_all_the_settings_saved_in_the_database()
     {
         $this->actingAs($this->user);
@@ -334,9 +292,7 @@ class SettingsTest extends TestCase
         ], $this->user->settings()->allSaved()->all());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function a_user_can_not_get_an_invalid_setting()
     {
         $this->actingAs($this->user);
@@ -348,9 +304,7 @@ class SettingsTest extends TestCase
         $this->assertNull($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function if_default_value_is_set_database_entry_is_deleted()
     {
         $this->actingAs($this->user);
@@ -361,7 +315,7 @@ class SettingsTest extends TestCase
             'test_settings1' => 'grapes',
         ]);
 
-        $this->seeInDatabase('property_bag', [
+        $this->assertDatabaseHas('property_bag', [
             'resource_id' => $this->user->id,
             'key'         => 'test_settings1',
             'value'       => json_encode('["grapes"]'),
@@ -371,7 +325,7 @@ class SettingsTest extends TestCase
             'test_settings1' => 'monkey',
         ]);
 
-        $this->dontSeeInDatabase('property_bag', [
+        $this->assertDatabaseMissing('property_bag', [
             'resource_id'   => $this->user->id,
             'resource_type' => 'LaravelPropertyBag\tests\Classes\User',
             'key'           => 'test_settings1',
@@ -379,14 +333,12 @@ class SettingsTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     *
-     * @expectedException LaravelPropertyBag\Exceptions\InvalidSettingsValue
-     * @expectedExceptionMessage Given value is not a registered allowed value for test_settings1.
-     */
+    #[Test]
     public function setting_an_unallowed_setting_value_throws_exception()
     {
+        $this->expectException(InvalidSettingsValue::class);
+        $this->expectExceptionMessage('Given value is not a registered allowed value for test_settings1.');
+
         $this->actingAs($this->user);
 
         $this->user->settings()->set([
@@ -394,9 +346,7 @@ class SettingsTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function invalid_setting_value_exception_should_contain_failed_key_name()
     {
         $this->actingAs($this->user);
@@ -410,9 +360,7 @@ class SettingsTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function settings_can_be_registered_in_config_file_method()
     {
         $post = $this->makePost();
@@ -436,9 +384,7 @@ class SettingsTest extends TestCase
         $this->assertEquals($actual, $allowed->all());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function settings_with_allowed_rule_can_be_set()
     {
         $comment = $this->makeComment();
@@ -463,22 +409,18 @@ class SettingsTest extends TestCase
         $this->assertEquals($settings, $comment->settings()->all()->all());
     }
 
-    /**
-     * @test
-     *
-     * @expectedException LaravelPropertyBag\Exceptions\InvalidSettingsValue
-     * @expectedExceptionMessage Given value is not a registered allowed value for alpha.
-     */
+    #[Test]
     public function settings_with_invalid_rule_values_can_not_be_set()
     {
+        $this->expectException(InvalidSettingsValue::class);
+        $this->expectExceptionMessage('Given value is not a registered allowed value for alpha.');
+
         $comment = $this->makeComment();
 
         $comment->settings()->set(['alpha' => 4]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function keyIs_returns_true_if_key_value_is_set()
     {
         $this->actingAs($this->user);
@@ -495,9 +437,7 @@ class SettingsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function keyIs_returns_false_if_key_value_is_not_set()
     {
         $this->actingAs($this->user);
@@ -514,9 +454,7 @@ class SettingsTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function reset_resets_setting_to_default_value()
     {
         $this->actingAs($this->user);
@@ -533,9 +471,7 @@ class SettingsTest extends TestCase
         $this->assertEquals('monkey', $this->user->settings('test_settings1'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function created_setting_is_immediately_available_for_reading()
     {
         $settings = $this->user->settings();
@@ -546,9 +482,7 @@ class SettingsTest extends TestCase
         $this->assertEquals(true, $settings->get('test_settings3'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updated_setting_is_immediately_available_for_reading()
     {
         $settings = $this->user->settings();
@@ -560,9 +494,7 @@ class SettingsTest extends TestCase
         $this->assertEquals('grapes', $settings->get('test_settings1'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function deleted_setting_is_immediately_available_for_reading()
     {
         $settings = $this->user->settings();
@@ -576,9 +508,7 @@ class SettingsTest extends TestCase
         $this->assertEquals('monkey', $settings->get('test_settings1'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function created_setting_is_immediately_available_for_reading_with_preloaded_relation()
     {
         $this->user->load('propertyBag');
@@ -590,9 +520,7 @@ class SettingsTest extends TestCase
         $this->assertEquals(true, $settings->get('test_settings3'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function updated_setting_is_immediately_available_for_reading_with_preloaded_relation()
     {
         $this->user->load('propertyBag');
@@ -605,9 +533,7 @@ class SettingsTest extends TestCase
         $this->assertEquals('grapes', $settings->get('test_settings1'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function deleted_setting_is_immediately_available_for_reading_with_preloaded_relation()
     {
         $this->user->load('propertyBag');

--- a/tests/Unit/TypeTest.php
+++ b/tests/Unit/TypeTest.php
@@ -3,12 +3,11 @@
 namespace LaravelPropertyBag\tests\Unit;
 
 use LaravelPropertyBag\tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class TypeTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_distinguishes_between_bool_and_int_types()
     {
         $this->actingAs($this->user);
@@ -32,9 +31,7 @@ class TypeTest extends TestCase
         $this->assertTrue($result !== true);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_distinguishes_between_bool_and_string_types()
     {
         $this->actingAs($this->user);
@@ -58,9 +55,7 @@ class TypeTest extends TestCase
         $this->assertTrue($result !== 'false');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_distinguishes_between_int_and_string_types()
     {
         $this->actingAs($this->user);


### PR DESCRIPTION
Ticket: https://linear.app/agent-software/issue/ST-232/update-agentsoftwarelaravel-property-bag

## Summary
The PR focus on our fork of laravel-property-bag up to Street's current baseline. The library code itself was already fine on modern PHP — the problem was the package declared support for PHP 7.1+ and its tests booted an old Laravel 6 app with PHPUnit 4-era tooling, so we couldn't trust or run it on our stack. composer.json now requires PHP ^8.2 and illuminate/* ^12.0, and the dead dev dependencies (laravel/laravel, laravel/browser-kit-testing, phpunit ~4) are replaced with Orchestra Testbench ^10 and PHPUnit ^11.

The test harness was rewritten to run standalone against an in-memory SQLite DB, and every test file was modernised to PHPUnit 11 syntax. 